### PR TITLE
Add mycat1.6 container autotest project.

### DIFF
--- a/mycat-allinone-docker-1.6/Dockerfile-mycat
+++ b/mycat-allinone-docker-1.6/Dockerfile-mycat
@@ -1,0 +1,44 @@
+FROM maven:3.5.3-jdk-8 as builder
+
+LABEL maintainer="HanSenJ <28707699@qq.com>"
+
+ARG TZ="UTC"
+ARG BUILD_USER="Mycat2"
+
+ENV TZ ${TZ}
+ENV REPO_ADDR https://github.com/MyCATApache/${BUILD_USER}.git
+
+RUN apt-get upgrade -y \
+    && apt-get install tzdata git -y \
+    && git clone ${REPO_ADDR} /mycat \
+    && (cd /mycat \
+    && git submodule init \
+    && git submodule update \
+    && mvn clean package -DskipTests) \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone \
+    && apt-get clean
+
+FROM openjdk:8u151-jdk
+
+ARG TZ="UTC"
+
+ENV TZ ${TZ}
+ENV MYCAT_HOME /usr/lib/mycat
+
+COPY --from=builder /mycat/dist/*.tar.gz /
+
+RUN apt-get upgrade -y \
+    && apt-get install tzdata -y \
+    && mkdir ${MYCAT_HOME} \
+	&& tar -zxf /*.tar.gz -C ${MYCAT_HOME} --strip-components 1 \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone \
+    && apt-get clean \
+    && rm -rf /*.tar.gz
+
+COPY bin/*.sh ${MYCAT_HOME}/bin/
+
+WORKDIR ${MYCAT_HOME}/bin
+
+CMD ["/bin/bash"]

--- a/mycat-allinone-docker-1.6/Dockerfile-mycat-web
+++ b/mycat-allinone-docker-1.6/Dockerfile-mycat-web
@@ -1,0 +1,40 @@
+FROM maven:3.5.3-jdk-8 as builder
+
+LABEL maintainer="HanSenJ <28707699@qq.com>"
+
+ARG TZ="UTC"
+ENV TZ ${TZ}
+ENV REPO_ADDR https://github.com/MyCATApache/Mycat-Web.git
+
+RUN apt-get upgrade -y \
+    && apt-get install tzdata git -y \
+    && git clone ${REPO_ADDR} /mycat-web \
+    && (cd /mycat \
+    && mvn clean package -DskipTests) \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone \
+    && apt-get clean
+
+FROM openjdk:8u151-jdk
+
+ARG TZ="UTC"
+
+ENV TZ ${TZ}
+ENV MYCATWEB_HOME /usr/lib/mycat-web
+
+COPY --from=builder /mycat-web/dist/*.tar.gz /
+
+RUN apt-get upgrade -y \
+    && apt-get install tzdata -y \
+    && mkdir ${MYCATWEB_HOME} \
+	&& tar -zxf /*.tar.gz -C ${MYCATWEB_HOME} --strip-components 1 \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone \
+    && apt-get clean \
+    && rm -rf /*.tar.gz
+
+COPY bin/*.sh ${MYCATWEB_HOME}/bin/
+
+WORKDIR ${MYCATWEB_HOME}/bin
+
+CMD ["/bin/bash"]

--- a/mycat-allinone-docker-1.6/build.sh
+++ b/mycat-allinone-docker-1.6/build.sh
@@ -1,0 +1,37 @@
+set -e
+
+export BUILD_USER=${BUILD_USER:-"mycat"}
+export TEST_TIMEZONE=${TEST_TIMEZONE:-"UTC"}
+
+while getopts "u:d:t:" OPT; do
+    case $OPT in
+        u)
+            BUILD_USER=$OPTARG;;
+        t)
+            TEST_TIMEZONE=$OPTARG;;
+    esac
+done
+
+echo -e "\033[32mTesting user ==> [${BUILD_USER}]\033[0m"
+echo -e "\033[32mUsing timezone ==> [${TEST_TIMEZONE}]\033[0m"
+
+if [ "${TEST_TIMEZONE}" == "UTC" ]; then
+    echo ""
+    echo -e "\033[32mTips: If you want to change timezone,use '-t' option(e.g., -t 'Asia/Shanghai').\033[0m"
+    echo -e "\033[32mSupported timezone reference: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones\033[0m"
+    echo ""
+    sleep 5
+fi
+
+echo "Building docker images..."
+docker build -t mycat  --build-arg BUILD_USER="${BUILD_USER}" \
+                            --build-arg TZ="${TZ}" \
+                            -f Dockerfile-mycat .
+                            
+docker build -t mycat-web --build-arg TZ="${TZ}" \
+                            -f Dockerfile-mycat-web .
+
+
+echo "Starting docker compose..."
+   docker-compose -f docker-compose.yaml up -d
+echo "Success!"

--- a/mycat-allinone-docker-1.6/docker-compose.yaml
+++ b/mycat-allinone-docker-1.6/docker-compose.yaml
@@ -1,0 +1,26 @@
+version: '3'
+services:
+  mycat:
+    container_name: mycat
+     image: mycat
+    restart: always
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "bootstrap.memory_lock=true"
+      - "discovery.type=single-node"
+      - "xpack.security.enabled=false"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    network_mode: "host"
+  mycat-web:
+    container_name: mycat-web
+    image: mycat-web:latest
+    restart: always
+    network_mode: "host"
+    volumes:
+      - ./mycat-web/application.yml
+    environment:
+      - TEST_DATABASE
+    command: ["bash","mycatWebService.sh"]

--- a/mycat-allinone-docker-1.6/mycatWebService.sh
+++ b/mycat-allinone-docker-1.6/mycatWebService.sh
@@ -1,0 +1,16 @@
+PRG="$0"
+PRGDIR=`dirname "$PRG"`
+[ -z "$WEBAPP_HOME" ] && WEBAPP_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
+
+WEBAPP_LOG_DIR="${WEBAPP_HOME}/logs"
+JAVA_OPTS=" -Xms256M -Xmx512M"
+JAR_PATH="${WEBAPP_HOME}/webapp"
+
+if [ ! -d "${WEBAPP_HOME}/logs" ]; then
+    mkdir -p "${WEBAPP_LOG_DIR}"
+fi
+
+_RUNJAVA=${JAVA_HOME}/bin/java
+[ -z "$JAVA_HOME" ] && _RUNJAVA=java
+
+"$_RUNJAVA" ${JAVA_OPTS} -jar ${JAR_PATH}/mycat-web.jar --server.port=8080


### PR DESCRIPTION
功能描述：根据输入mycat版本号进行github代码下载编译打包，打镜像及关联mycat-web工程于docker-compose启动。
1、增加/bin目录作为自动化运行目录。
2、增加docker-compose.yaml运行mycat主工程及web工程服务。
3、增加Dockerfile-mycat、Dockerfile-mycat-web作为主工程及web工程的dockerfile。
4、增加mycatWebServer.sh作为mycat-web服务的启动运行参数配置。
5、增加build.sh 作为一键运行启动命令。